### PR TITLE
Remove `app` module

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':buffertextinputlayout', ':sample'
+include ':buffertextinputlayout', ':sample'


### PR DESCRIPTION
Looks like `app` was renamed to `sample`, but the `settings` was still including `app`. This will remove it. 